### PR TITLE
Proposed Fix for Skill Name Mapping Issue

### DIFF
--- a/src/LinkedINSharp/Model/People/Person.cs
+++ b/src/LinkedINSharp/Model/People/Person.cs
@@ -178,9 +178,9 @@ namespace LinkedINSharp.Model.People
 		/// </summary>
 		public Collection< Language > Languages { get; set; }
 		/// <summary>
-		/// A collection of <see cref="Skill"/>s and the level of the member's proficiency for each.
+		/// A collection of <see cref="SkillItem"/>s and the level of the member's proficiency for each.
 		/// </summary>
-		public Collection< Skill > Skills { get; set; }
+		public Collection< SkillItem > Skills { get; set; }
 		/// <summary>
 		/// A collection of <see cref="Certification"/>s earned by this member.
 		/// </summary>

--- a/src/LinkedINSharp/Model/People/Skill.cs
+++ b/src/LinkedINSharp/Model/People/Skill.cs
@@ -3,7 +3,7 @@ namespace LinkedINSharp.Model.People
 	/// <summary>
 	/// A skill held by a member.
 	/// </summary>
-	public class Skill
+	public class SkillItem
 	{
 		#region Properties
 		/// <summary>
@@ -13,7 +13,7 @@ namespace LinkedINSharp.Model.People
 		/// <summary>
 		/// A structured object that indicates the internationalized name of the canonical language
 		/// </summary>
-		public SkillName Name { get; set; }
+		public SkillName Skill { get; set; }
 		/// <summary>
 		/// A structured object indicating the user's skill level
 		/// </summary>


### PR DESCRIPTION
Skill names are failing to populate, due to a mismatch in the named
property "Name" in the Skill class.  The REST response from LinkedIn
returns a nested Skill node, which in turn, contains the name.  Proposed
modifications are to rename the Skill class as SkillItem so that the
"Name" property in that class can be renamed to "Skill", in order for it
to populate.
